### PR TITLE
Update test to proper phpunit namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea
+.vscode
 node_modules
 /vendor/
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ Fixtures for all mixtures 👋
 * SilverStripe ^4.0 || ^5.0
 * PHP ^7.4 || ^8.0
 
+## Dev requirements
+
+* `phpunit/phpunit` ^9.5
+* `squizlabs/php_codesniffer` ^3.0
+
 ## Installation
 ```
 composer require adrhumphreys/silverstripe-fixtures dev-master

--- a/tests/KhanSorterTest.php
+++ b/tests/KhanSorterTest.php
@@ -2,11 +2,10 @@
 
 namespace AdrHumphreys\Fixtures\Tests;
 
-
 use AdrHumphreys\Fixtures\KahnSorter;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class KhanSorterTest extends PHPUnit_Framework_TestCase
+class KhanSorterTest extends TestCase
 {
     public function testSorter()
     {


### PR DESCRIPTION
Phpunit changed the class name to proper namespacing.

This cause some issues.

Requires a specific chain of settings to encounter this, that aren't really important to this PR.

But this should be updated.


Update:
> The outdated phpunit class here will cause an issue when installing this package via `composer --prefer-source`. This class will then get included in composer's autoloader and if you run it with phpunit >6.4 it will cause an exception because the class is no longer available.

